### PR TITLE
Fixed Assembly Lock Issue

### DIFF
--- a/src/IowaComputerGurus.Dnn.TelerikIdentifier/Controllers/ContentController.cs
+++ b/src/IowaComputerGurus.Dnn.TelerikIdentifier/Controllers/ContentController.cs
@@ -32,7 +32,7 @@ namespace IowaComputerGurus.Dnn.TelerikIdentifier.Controllers
             {
                 try
                 {
-                    var references = Assembly.LoadFile(file).GetReferencedAssemblies();
+                    var references = Assembly.Load(System.IO.File.ReadAllBytes(file)).GetReferencedAssemblies();
                     var foundTelerik =
                         references.Any(r => r.FullName.StartsWith("Telerik", true, CultureInfo.InvariantCulture));
                     if (!foundTelerik)

--- a/src/IowaComputerGurus.Dnn.TelerikIdentifier/IowaComputerGurus.Dnn.TelerikIdentifier.dnn
+++ b/src/IowaComputerGurus.Dnn.TelerikIdentifier/IowaComputerGurus.Dnn.TelerikIdentifier.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="IowaComputerGurus.Dnn.TelerikIdentifier" type="Module" version="01.00.01">
+    <package name="IowaComputerGurus.Dnn.TelerikIdentifier" type="Module" version="01.00.02">
       <friendlyName>Telerik Identifier</friendlyName>
       <description>A module to help identify possible Telerik dependencies</description>
       <iconFile />


### PR DESCRIPTION
Resolves #4 by reading assemblies into memory THEN looking for referenced assemblies, preventing issues with file locks